### PR TITLE
fix the data type issue when primary key is a custom type

### DIFF
--- a/DaoGenerator/src-template/dao.ftl
+++ b/DaoGenerator/src-template/dao.ftl
@@ -245,7 +245,7 @@ as property>\"${property.dbName}\"<#if (index.propertiesOrder[property_index])??
 </#if>
         return rowId;
 <#else>
-        return entity.get${entity.pkProperty.propertyName?cap_first}();
+        return (${entity.pkType}) entity.get${entity.pkProperty.propertyName?cap_first}();
 </#if>
 <#else>
         // Unsupported or missing PK type
@@ -257,7 +257,7 @@ as property>\"${property.dbName}\"<#if (index.propertiesOrder[property_index])??
     public ${entity.pkType} getKey(${entity.className} entity) {
 <#if entity.pkProperty??>
         if(entity != null) {
-            return entity.get${entity.pkProperty.propertyName?cap_first}();
+            return (${entity.pkType}) entity.get${entity.pkProperty.propertyName?cap_first}();
         } else {
             return null;
         }


### PR DESCRIPTION
fix for issue https://github.com/greenrobot/greenDAO/issues/1051
When primary key is a custom type, the generated code for updateKeyAfterInsert and getKey will return String but the actual primary key is not.